### PR TITLE
fix: cube pagination table data gets overridden on size change

### DIFF
--- a/src/components/cube/CubePagination/index.jsx
+++ b/src/components/cube/CubePagination/index.jsx
@@ -91,6 +91,11 @@ export default class CubePagination extends Component {
 
   onPageChange = (pageNumber) => {
     const { pageSize } = this.state;
+    if (pageNumber === this.state.current) {
+      // Check for equality because this function will be called on show size change
+      // by the design of antd Pagination.
+      return;
+    }
     this.setState(
       {
         current: pageNumber,


### PR DESCRIPTION
Close #41

https://github.com/user-attachments/assets/791c6cd1-7f44-4310-bfc5-8997b4b27963

