### PR TITLE
54 hide unsupported share protocols (keep NFS/CIFS)

### DIFF
--- a/src/resources/manila/share.js
+++ b/src/resources/manila/share.js
@@ -41,13 +41,18 @@ export const replicaState = {
   out_of_sync: t('Out of Sync'),
 };
 
+/**
+ * Currently, only NFS and CIFS are supported as share protocol options.
+ * Other options have been commented out rather than removed entirely,
+ * in case support for them is reinstated in the future.
+ */
 export const shareProtocol = {
   NFS: t('NFS'),
   CIFS: t('CIFS'),
-  GlusterFS: t('GlusterFS'),
-  HDFS: t('HDFS'),
-  CephFS: t('CephFS'),
-  MAPRFS: t('MAPRFS'),
+  // GlusterFS: t('GlusterFS'),
+  // HDFS: t('HDFS'),
+  // CephFS: t('CephFS'),
+  // MAPRFS: t('MAPRFS'),
 };
 
 export const shareVisibility = {


### PR DESCRIPTION
#### What type of PR is this?

- Chore

#### What this PR does / why we need it

- Temporarily hide unsupported share protocol options, retaining only NFS and CIFS. 


<img width="1507" alt="Screenshot 2025-05-02 at 3 04 38 PM" src="https://github.com/user-attachments/assets/f2b72e10-8530-4abf-b488-a83a9122885c" />



#### Which issue(s) this PR fixes

Fixes #54 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
