### PR TITLE
63 unexpected error when entering the create instance page

### DIFF
--- a/src/pages/compute/containers/Instance/actions/StepCreate/index.jsx
+++ b/src/pages/compute/containers/Instance/actions/StepCreate/index.jsx
@@ -279,16 +279,35 @@ export class StepCreate extends StepAction {
   }
 
   getQuotaMessage(value, quota, name) {
-    const { left = 0 } = quota || {};
+    /**
+     * `quota` may be undefined,
+     * return an empty string to avoid unexpected errors.
+     */
+    if (!quota) return '';
+    /**
+     * Get the remaining quota (`left`), defaulting to 0
+     */
+    const left = quota.left ?? 0;
+    /**
+     * If `left` is -1, there is no message needed.
+     */
     if (left === -1) {
       return '';
     }
+    /**
+     * If the input value exceeds the remaining quota,
+     * return a warning message with the relevant values.
+     */
     if (value > left) {
       return t(
         'Insufficient {name} quota to create resources (left { quota }, input { input }).',
         { name, quota: left, input: value }
       );
     }
+    /**
+     * If none of the above conditions apply,
+     * return an empty string (no warning needed).
+     */
     return '';
   }
 


### PR DESCRIPTION
Close #63 

#### Description

In the former implementation of `checkVolumeQuota`, when `quota` is `undefined`, `quota.left` is treated as `0`. This causes the issue reported in #63, where an error message appears the first time the user enters the `Create Instance` page — because `quota.left` is interpreted as `0`.

#### Fix

This PR adjusts the timing of the `quota` check and error message display:

- When `quota` is still `undefined`, the app will not return an error message.
- The `quota` check will proceed once the` quota` data is available, or when the user switches the system disk — maintaining the original logic for that case.

https://github.com/user-attachments/assets/d5c7d6bb-484e-4f67-9b47-aaccb0bbac02