### PR TITLE
73 fix: adjust icon size in hypervisor table

### DIFF
--- a/src/components/Tables/Base/index.jsx
+++ b/src/components/Tables/Base/index.jsx
@@ -351,10 +351,10 @@ export class BaseTable extends React.Component {
         return realValue;
       }
       return (
-        <div>
+        <div style={{ display: 'flex' }}>
           {realValue}
           <Tooltip title={tipValue}>
-            <Icon style={{ marginLeft: 8 }} />
+            <Icon width={16} height={16} style={{ marginLeft: 8 }} />
           </Tooltip>
         </div>
       );


### PR DESCRIPTION
#### Description

- Close #73 

- Adjust icon size in hypervisor table

[Before]

![444954558-0af4f380-8e81-4965-bc7f-9cb3b6c15e71](https://github.com/user-attachments/assets/a9ba8d7d-dfb7-46d9-a0ab-300842f4aff7)


[After]

<img width="1509" alt="Screenshot 2025-05-20 at 5 45 57 PM" src="https://github.com/user-attachments/assets/44782b9f-14d4-49a8-b70c-b0d90a4d40fb" />
