### PR TITLE
fix: 48 IAM admin does not have admin project permission

### DIFF
--- a/src/client/keystone/index.js
+++ b/src/client/keystone/index.js
@@ -28,6 +28,11 @@ export class KeystoneClient extends Base {
         responseKey: 'catalog',
       },
       {
+        name: 'authProjects',
+        key: 'auth/projects',
+        responseKey: 'projects',
+      },
+      {
         key: 'projects',
         responseKey: 'project',
         extendOperations: [

--- a/src/stores/keystone/user.js
+++ b/src/stores/keystone/user.js
@@ -15,7 +15,6 @@
 import { action, observable } from 'mobx';
 import List from 'stores/base-list';
 import client from 'client';
-import globalRootStore from 'stores/root';
 import globalProjectStore from 'stores/keystone/project';
 import globalGroupStore from 'stores/keystone/user-group';
 import Base from 'stores/base';
@@ -46,6 +45,10 @@ export class UserStore extends Base {
 
   get projectClient() {
     return client.keystone.projects;
+  }
+
+  get authProjectClient() {
+    return client.keystone.authProjects;
   }
 
   get systemUserClient() {
@@ -126,12 +129,7 @@ export class UserStore extends Base {
     this.userProjects.update({
       isLoading: true,
     });
-    const {
-      user: {
-        user: { id },
-      },
-    } = globalRootStore;
-    const { projects } = await this.client.projects.list(id);
+    const { projects } = await this.authProjectClient.list();
     this.userProjects.update({
       data: projects,
       isLoading: false,


### PR DESCRIPTION
### Description

Summary:

1. The projects displayed in the project list dropdown should match those shown in `Horizon`.
2. Since the `admin (IAM)` is federated user (from `Keycloak`),  projects should retrieved using the `GET /v3/users/<USER_ID>/projects` API, which is same as `Horizon`.

For more details, please refer to this comment: https://github.com/bigstack-oss/skyline-console/issues/48#issuecomment-2965567844

### Screenshots

https://github.com/user-attachments/assets/0f46eafa-3d12-4067-87bb-02694d56b6ec


#### Addition Notes

Since we cannot test the `admin (IAM)` user in the local development environment, I temporarily overrode the static files at the following path:`/usr/local/lib/python3.9/site-packages/skyline_console/static`.

Fix #48 