### PR TITLE
chore: scp local dist to dev remote scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ skyline_console/static
 
 # config
 test/e2e/config/local_config.yaml
+*.local
 
 # Python
 __pycache__/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "test:e2e:open": "cypress open",
     "test:e2e:server": "cross-env NODE_ENV=test webpack-dev-server --open --progress --config config/webpack.e2e.js",
     "test:unit": "cross-env NODE_ENV=development jest",
-    "test:unit:coverage": "cross-env NODE_ENV=development jest --coverage"
+    "test:unit:coverage": "cross-env NODE_ENV=development jest --coverage",
+    "deploy-dev": "./scripts/deployToDevRemote.sh",
+    "predeploy-dev": "yarn build"
   },
   "husky": {
     "hooks": {

--- a/scripts/deployToDevRemote.sh
+++ b/scripts/deployToDevRemote.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Set TRACE=1 to enable debugging: `TRACE=1 $0`
+[[ -n "${TRACE-}" ]] && set -x
+
+SH_DIR=$(dirname "$(realpath "$0")")
+ROOT_DIR=$(dirname "$SH_DIR")
+LOCAL_DIST_DIR="${ROOT_DIR}/skyline_console/static"
+HOST_CONFIG_FILE="${SH_DIR}/remote_hosts.properties.local"
+
+source "${HOST_CONFIG_FILE}"
+
+if [[ ! -d "$LOCAL_DIST_DIR" ]]; then
+  echo "Error: Local distribution directory does not exist: $LOCAL_DIST_DIR"
+  exit 1
+fi
+
+for remote_host in "${remote_hosts[@]}"; do
+  backup_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  skyline_console_backup_path="${skyline_console_path}.${backup_date}.bak"
+
+  ssh_host="${user}@${remote_host}"
+  scp_skyline_console_path="${ssh_host}:${skyline_console_path}"
+  scp_skyline_console_backup_path="${ssh_host}:${skyline_console_backup_path}"
+
+  echo "[${ssh_host}] Backup: ${scp_skyline_console_path} -> ${scp_skyline_console_backup_path}"
+  ssh "$ssh_host" "mv ${skyline_console_path} ${skyline_console_backup_path}"
+
+  echo "[${ssh_host}] Deploy: ${LOCAL_DIST_DIR} -> $scp_skyline_console_path"
+  scp -r "$LOCAL_DIST_DIR" "$scp_skyline_console_path"
+done

--- a/scripts/remote_hosts.properties.example
+++ b/scripts/remote_hosts.properties.example
@@ -1,0 +1,3 @@
+user="username"
+remote_hosts=("10.0.0.1" "10.0.0.2" "10.0.0.3")
+skyline_console_path="/usr/local/lib/python3.9/site-packages/skyline_console/static"


### PR DESCRIPTION
### Changes

The `./scripts/deployToDevRemote.sh` command is designed to allow frontend developers to quickly test features or fixes on remote dev hosts.

1. Copy the `./scripts/remote_hosts.properties.example` file to `./scripts/remote_hosts.properties.local` (which is git-ignored) and fill in all properties.
2. Run `./scripts/deployToDevRemote.sh`. This command will use `scp` to deploy it to the specified dev hosts.