### PR TITLE
98 Update OS Data Source to Match Icon Display

### DIFF
--- a/src/components/ImageType/index.jsx
+++ b/src/components/ImageType/index.jsx
@@ -15,6 +15,7 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import { upperFirst } from 'lodash';
 import { Tooltip } from 'antd';
 import centosIcon from 'asset/image/centos.svg';
 import ubuntuIcon from 'asset/image/ubuntu.svg';
@@ -49,13 +50,30 @@ export default class index extends Component {
       coreos: coreosIcon,
       arch: archIcon,
       freebsd: freebsdIcon,
+      other: othersIcon,
       others: othersIcon,
+    };
+    this.titles = {
+      centos: 'CentOS',
+      ubuntu: 'Ubuntu',
+      fedora: 'Fedora',
+      windows: 'Windows',
+      debian: 'Debian',
+      coreos: 'CoreOS',
+      arch: 'Arch',
+      freebsd: 'FreeBSD',
+      other: 'Other',
+      others: 'Others',
     };
   }
 
   render() {
-    const { type, className, title } = this.props;
+    const { type, className, title: titleProp } = this.props;
+
     const IconComponent = this.icons[type?.toLowerCase()] || othersIcon;
+
+    const title =
+      this.titles[titleProp?.toLowerCase()] || upperFirst(titleProp);
 
     const iconElement = (
       <IconComponent className={classnames(styles.image, className)} />

--- a/src/pages/compute/containers/Image/Image.jsx
+++ b/src/pages/compute/containers/Image/Image.jsx
@@ -228,7 +228,7 @@ export class Image extends BaseList {
       },
       {
         title: t('OS'),
-        dataIndex: 'os',
+        dataIndex: 'imageOS',
         width: 80,
         sorter: false,
         render: (value) => <ImageType type={value} title={value} />,


### PR DESCRIPTION
#### What type of PR is this?

- Bug

#### What this PR does / why we need it

- Replace OS data from the COS API to match the icon display

<img width="1512" height="823" alt="Screenshot 2025-09-11 at 3 51 51 PM" src="https://github.com/user-attachments/assets/b4592249-e47f-4d1a-a970-9560dfdc58f0" />


#### Which issue(s) this PR fixes

Fixes #98 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
