### PR TITLE
Fix: Display Volume List Correspondingly in Instance Detail Page

### DIFF
--- a/src/pages/storage/containers/Volume/index.jsx
+++ b/src/pages/storage/containers/Volume/index.jsx
@@ -19,6 +19,7 @@ import {
   volumeTransitionStatuses,
   volumeFilters,
   getVolumeColumnsList,
+  getCosVolumeColumnsList,
 } from 'resources/cinder/volume';
 import cosVolumeStore from 'stores/cos/volume';
 import { SnapshotVolumeStore } from 'stores/cinder/snapshot-volume';
@@ -102,7 +103,12 @@ export class Volume extends BaseList {
   }
 
   getColumns = () => {
-    return getVolumeColumnsList(this);
+    // In Volume Snapshot page or Instance detail page, use the cinder volume columns
+    // In Volume list page, use the COS volume columns instead
+    if (this.isVolumeSnapshotDetail || this.inDetailPage) {
+      return getVolumeColumnsList(this);
+    }
+    return getCosVolumeColumnsList(this);
   };
 
   get searchFilters() {
@@ -111,7 +117,7 @@ export class Volume extends BaseList {
 
   get itemInTransitionFunction() {
     return ({ volumeStatus }) => {
-      return volumeStatus.isProcessing;
+      return volumeStatus?.isProcessing || false;
     };
   }
 

--- a/src/resources/cinder/volume.jsx
+++ b/src/resources/cinder/volume.jsx
@@ -263,6 +263,133 @@ export const getVolumeColumnsList = (self) => {
   return [
     {
       title: t('ID/Name'),
+      dataIndex: 'name',
+      routeName: self.getRouteName('volumeDetail'),
+      sortKey: 'name',
+      render: (name, row) => (
+        <div className={styles['title-col']}>
+          <span className={styles['volume-name']}>{name}</span>
+          <div className={styles['volume-id-row']}>
+            <Tooltip title={row.id}>
+              <Link
+                className={styles['volume-id-link']}
+                to={
+                  self.isAdminPage
+                    ? `/storage/volume-admin/detail/${row.id}`
+                    : `/storage/volume/detail/${row.id}`
+                }
+              >
+                {row.id}
+              </Link>
+            </Tooltip>
+            <CubeCopyButton>{row.id}</CubeCopyButton>
+          </div>
+        </div>
+      ),
+    },
+    {
+      title: t('Project ID/Name'),
+      dataIndex: 'project_name',
+      hidden: !self.isAdminPage,
+      isHideable: true,
+      sorter: false,
+    },
+    {
+      title: t('Host'),
+      dataIndex: 'host',
+      isHideable: true,
+      hidden: !self.isAdminPage,
+      sorter: false,
+    },
+    {
+      title: t('Size'),
+      dataIndex: 'size',
+      isHideable: true,
+      unit: 'GiB',
+    },
+    {
+      title: t('Status'),
+      dataIndex: 'status',
+      valueMap: volumeStatus,
+    },
+    {
+      title: t('Type'),
+      dataIndex: 'volume_type',
+      isHideable: true,
+      width: 100,
+      sorter: false,
+    },
+    {
+      title: t('Disk Tag'),
+      dataIndex: 'disk_tag',
+      isHideable: true,
+      valueMap: diskTag,
+      sorter: false,
+    },
+    {
+      title: t('Attached To'),
+      dataIndex: 'attachments',
+      isHideable: true,
+      sorter: false,
+      hidden: self.isInstanceDetail,
+      render: (value) => {
+        if (value && value.length > 0) {
+          return value.map((it) => (
+            <div key={it.server_id}>
+              {it.device} on{' '}
+              {self.getLinkRender(
+                'instanceDetail',
+                it.server_name || it.server_id,
+                { id: it.server_id },
+                { tab: 'volumes' }
+              )}
+            </div>
+          ));
+        }
+        return '-';
+      },
+      stringify: (value) => {
+        if (value && value.length) {
+          return value
+            .map((it) => {
+              const { device, server_name, server_id } = it;
+              return `${device} on ${server_name || '-'}(${server_id})`;
+            })
+            .join(',');
+        }
+        return '-';
+      },
+    },
+    {
+      title: t('Bootable'),
+      titleTip: t(
+        'When the volume is "bootable" and the status is "available", it can be used as a startup source to create an instance.'
+      ),
+      dataIndex: 'bootable',
+      isHideable: true,
+      valueMap: bootableType,
+    },
+    {
+      title: t('Shared'),
+      dataIndex: 'multiattach',
+      valueRender: 'yesNo',
+      titleTip: multiTip,
+      width: 80,
+      sorter: false,
+    },
+    {
+      title: t('Created At'),
+      dataIndex: 'created_at',
+      isHideable: true,
+      valueRender: 'sinceTime',
+    },
+  ];
+};
+
+export const getCosVolumeColumnsList = (self) => {
+  return [
+    {
+      title: t('ID/Name'),
       dataIndex: 'volumeName',
       routeName: self.getRouteName('volumeDetail'),
       sortKey: 'name',


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- In Volume Snapshot page or Instance detail page, use the cinder volume columns
- In Volume list page, use the COS volume columns instead

## Before

<img width="1511" height="822" alt="Screenshot 2025-10-01 at 4 01 41 PM" src="https://github.com/user-attachments/assets/bdd022df-8484-45fb-9c37-5d52dbca77e5" />

## After

Uploading Screen Recording 2025-10-01 at 3.53.33 PM.mov…

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
