### PR TITLE
429 Use Snapshot Size When Creating Instance from Snapshot

### DIFF
--- a/src/pages/compute/containers/Instance/actions/StepCreate/ConfirmStep/index.jsx
+++ b/src/pages/compute/containers/Instance/actions/StepCreate/ConfirmStep/index.jsx
@@ -40,11 +40,18 @@ export class ConfirmStep extends Base {
 
   allowed = () => Promise.resolve();
 
-  getDisk(diskInfo, bootFromVolume) {
+  getDisk(diskInfo, bootFromVolume, selectedInstanceSnapshot) {
     if (!bootFromVolume) {
       return null;
     }
+
     const { size, typeOption, deleteTypeLabel } = diskInfo || {};
+
+    if (selectedInstanceSnapshot) {
+      const sizeGiB = selectedInstanceSnapshot.min_disk ?? 0;
+      return `${typeOption.label} ${sizeGiB}GiB ${deleteTypeLabel}`;
+    }
+
     return `${typeOption.label} ${size}GiB ${deleteTypeLabel}`;
   }
 
@@ -72,7 +79,13 @@ export class ConfirmStep extends Base {
       return this.getBootableVolumeDisk();
     }
     if (value === 'instanceSnapshot' && instanceSnapshotDisk !== null) {
-      return this.getDisk(instanceSnapshotDisk, bootFromVolume);
+      const selectedInstanceSnapshot =
+        context.instanceSnapshot?.selectedRows?.[0];
+      return this.getDisk(
+        instanceSnapshotDisk,
+        bootFromVolume,
+        selectedInstanceSnapshot
+      );
     }
     return this.getDisk(systemDisk, bootFromVolume);
   }


### PR DESCRIPTION
#### What type of PR is this?

- Bug

#### What this PR does / why we need it

- When creating an instance from a snapshot backed by an external volume, the frontend incorrectly validated against the `min_disk` value, causing instance creation to fail. This update uses the snapshot's `size` attribute to decide the minimum required system disk instead.
- The full discussion please see: https://bigstack-tech.slack.com/archives/C07GL6RKCHM/p1762419311302799

#### Which issue(s) this PR fixes

Fixes https://github.com/orgs/bigstack-oss/projects/17/views/1?filterQuery=assignee%3Alizzy-liang-bigstack&pane=issue&itemId=136592611&issue=bigstack-oss%7Ccubecos%7C429

#### Special notes for your reviewer

> Note

#### Steps to Reproduce the Issue

As described under the ticket:

<img width="880" height="334" alt="Screenshot 2025-11-10 at 11 32 43 AM" src="https://github.com/user-attachments/assets/c1c87399-bc11-4d00-b2fa-57831e91cce1" />

1. Log in to the provided environment using the authentication information.

2. Locate the volume named `VMware_vmdk`. This volume was importedfrom another hypervisor.

<img width="1510" height="821" alt="Screenshot 2025-11-07 at 4 39 21 PM" src="https://github.com/user-attachments/assets/129f4c23-aad3-4622-9a01-bddf87da9a1b" />

3. Find the instance named `VMware_vmdk` that was created from the volume.

<img width="1512" height="822" alt="Screenshot 2025-11-07 at 4 39 58 PM" src="https://github.com/user-attachments/assets/6f8cbe23-65b4-4df7-a666-df53a02ed763" />

4. Create an instance snapshot named  `snap_vmware_vmdk` from the instance.

<img width="1511" height="823" alt="Screenshot 2025-11-07 at 4 40 27 PM" src="https://github.com/user-attachments/assets/c699099b-cb91-422d-8190-daeb147241bc" />

5. When trying to create a new instance from this snapshot, we can see the system disk information below.

https://github.com/user-attachments/assets/f65015da-a308-411c-b925-7a676a80f294

---

Update by Steven: The code has been updated to display the minimum disk size when creating an instance from an instance snapshot:

<img width="2533" height="1344" alt="image" src="https://github.com/user-attachments/assets/e2102c86-e70c-494f-88c9-d59c9d4f8e78" />

<img width="2560" height="1342" alt="image" src="https://github.com/user-attachments/assets/d1f9c5ec-4748-427c-ae14-a64e897b6d29" />

