### PR TITLE
121 Use Default Pagination Options for the Volume Listing Page

### DIFF
--- a/src/pages/storage/containers/Volume/index.jsx
+++ b/src/pages/storage/containers/Volume/index.jsx
@@ -97,11 +97,6 @@ export class Volume extends BaseList {
     return 'created_at';
   }
 
-  get pageSizeOptions() {
-    // should be array of numbers
-    return [10];
-  }
-
   getColumns = () => {
     // In Volume Snapshot page or Instance detail page, use the cinder volume columns
     // In Volume list page, use the COS volume columns instead


### PR DESCRIPTION
#### What type of PR is this?

- Fix

#### What this PR does / why we need it

1. Set pagination options to defaults on the volume listing page
2. Ensure the table behaves correctly with the updated pagination options (pagination is handled on the frontend)


https://github.com/user-attachments/assets/317d2ebd-0246-4d65-b7e3-56788ab74db6



#### Which issue(s) this PR fixes

Fixes #121 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
